### PR TITLE
Fix: Improve readability of comments in solid/open_close.rb

### DIFF
--- a/solid/open_close.rb
+++ b/solid/open_close.rb
@@ -45,7 +45,10 @@ end
 
 # Solution
 
-# With this refactor we’ve made it possible to add new parsers without changing any code. Any additional behavior will only require the addition of a new handler. This makes our FileParser reusable and in many cases will keep us in compliance with the Single Responsibility Principle as well by encouraging us to create smaller more focused classes.
+# With this refactor we’ve made it possible to add new parsers without changing any code. 
+# Any additional behavior will only require the addition of a new handler. This makes our 
+# FileParser reusable and in many cases will keep us in compliance with the 
+# Single Responsibility Principle as well by encouraging us to create smaller more focused classes.
 
 class FileParser
   attr_reader :parser


### PR DESCRIPTION
This PR improves the readability of comments in _solid/open_close.rb_ by breaking long comment lines into shorter lines that fit within the standard width of the editor, avoiding horizontal scrolling. Fixes #44